### PR TITLE
Allow for a fallback value

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,12 +26,12 @@ module.exports = curry2(remap)
  * When matched returns corresponding mapped value; otherwise, an empty string.
  */
 
-function remap (map, str) {
+function remap (map, fallback, str) {
   str = string.call(str) === '[object String]' ? str : ''
 
   for (var key in map) {
     if (str.match(new RegExp(key, 'i'))) return map[key]
   }
 
-  return ''
+  return fallback || null
 }


### PR DESCRIPTION
I use this library for a frontend/backend routing layer and it would be super useful to have a default built-in. In addition it's not very valuable to have `''` be the result of non-matches.
